### PR TITLE
Firefox: Prevent selection of text in slider

### DIFF
--- a/css/pages/main.css
+++ b/css/pages/main.css
@@ -395,6 +395,7 @@ h6 {
   margin: auto;
   width: 100%;
   user-select: none;
+  -moz-user-select: none;
   top: 0;
   bottom: 0;
   left: 0;


### PR DESCRIPTION
Hi, I ran into annoying behavior when using the extension in Firefox: when I drag the slider on off page, I keep on selecting the text in slider. I have noticed that there's already `user-select` property for Chrome, however Firefox [still requires prefixing](https://caniuse.com/#feat=user-select-none) the property, so this is what I have added in this PR.

